### PR TITLE
Switch to ReactNative Linking API

### DIFF
--- a/link.js
+++ b/link.js
@@ -14,9 +14,8 @@ var {
   Text,
   TouchableHighlight,
   View,
+  Linking,
 } = React;
-
-var URLHandler = require('react-native-url-handler');
 
 var Link = React.createClass({
   render() {
@@ -27,10 +26,10 @@ var Link = React.createClass({
 
   _linkPressed() {
     if (this.props.url) {
-      URLHandler.openURL(this.props.url);
+      Linking.openURL(this.props.url);
     } else if (this.props.to && this.props.to.uri) {
       var url = this.props.to.uri;
-      URLHandler.openURL(url);
+      Linking.openURL(url);
     } else {
       console.error("Invalid Link destination:", this.props.to);
     }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   "bugs": {
     "url": "https://github.com/expo/react-native-link/issues"
   },
-  "homepage": "https://github.com/expo/react-native-link#readme",
-  "peerDependencies": {
-    "react-native-url-handler": "*"
-  }
+  "homepage": "https://github.com/expo/react-native-link#readme"
 }


### PR DESCRIPTION
Based on https://docs.expo.io/versions/latest/guides/linking.html

Using this component throw an error right now.